### PR TITLE
Add ROI output and update prediction docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # urp3_meshi
+
+Utilities for training and evaluating a U-Net model on CP-AnemiC ROI images.
+
+## Prediction outputs
+
+During validation, `save_preds` stores three image types:
+
+- `*_pred.png`: binary mask of the predicted region.
+- `*_roi.png`: original image masked by the prediction. Use this file for Hb prediction.
+- `*_overlay.png`: overlay of the mask for visualization only.
+

--- a/train_unet.py
+++ b/train_unet.py
@@ -221,11 +221,14 @@ def save_preds(model, loader, device, out_dir:Path, max_save:int=6):
                 if saved>=max_save: return
                 im = (imgs[i].cpu().numpy().transpose(1,2,0)*255).astype(np.uint8)
                 pr = (probs[i,0]>0.5).astype(np.uint8)*255
+                roi = im.copy()
+                roi[pr==0] = 0
                 ov = im.copy()
-                red = np.zeros_like(im); red[:,:,2]=255
-                ov[pr>0]=cv2.addWeighted(im,0.6,red,0.4,0)[pr>0]
+                red = np.zeros_like(im); red[:,:,2] = 255
+                ov[pr>0] = cv2.addWeighted(im, 0.6, red, 0.4, 0)[pr>0]
                 stem = Path(names[i]).stem
                 cv2.imwrite(str(out_dir/f"{stem}_pred.png"), pr)
+                cv2.imwrite(str(out_dir/f"{stem}_roi.png"), roi)
                 cv2.imwrite(str(out_dir/f"{stem}_overlay.png"), ov)
                 saved+=1
 


### PR DESCRIPTION
## Summary
- Generate ROI images in `save_preds` by masking predictions
- Document that Hb prediction should use `*_roi.png` and keep overlays for visualization

## Testing
- `python -m py_compile train_unet.py`
- `python train_unet.py --help` *(fails: No module named 'torch')*
- `pip install torch --index-url https://download.pytorch.org/whl/cpu` *(fails: Could not find a version that satisfies the requirement torch)*

------
https://chatgpt.com/codex/tasks/task_e_68bc3bf5fa20832bbf1c01ea6e6fdc1e