### PR TITLE
Allow fixed gate and padding options

### DIFF
--- a/v3_main.py
+++ b/v3_main.py
@@ -38,7 +38,7 @@ def parse_args():
     ap.add_argument("--dry-run", action="store_true")
 
     # ROI 파라미터 -> RoiConfig에 주입
-    ap.add_argument("--gate", choices=[None, "shemo"], default=None)
+    ap.add_argument("--gate", choices=["fixed", "shemo"], default="fixed")
     ap.add_argument("--segments", type=int, default=160)
     ap.add_argument("--compactness", type=float, default=10.0)
     ap.add_argument("--a_percentile", type=float, default=80)
@@ -46,6 +46,8 @@ def parse_args():
     # (옵션) 게이트 추가 파라미터도 받기
     ap.add_argument("--gate-offset-frac", type=float, default=None)
     ap.add_argument("--gate-lr-frac", type=float, default=None)
+    ap.add_argument("--roi-pad", type=int, default=None)
+    ap.add_argument("--dilate-radius", type=int, default=None)
 
     ap.add_argument("--no-skin-suppress", action="store_true")
     return ap.parse_args()
@@ -73,6 +75,10 @@ def main():
         cfg.gate_offset_frac = args.gate_offset_frac
     if args.gate_lr_frac is not None and hasattr(cfg, "gate_lr_margin_frac"):
         cfg.gate_lr_margin_frac = args.gate_lr_frac
+    if args.roi_pad is not None and hasattr(cfg, "roi_pad"):
+        cfg.roi_pad = args.roi_pad
+    if args.dilate_radius is not None and hasattr(cfg, "dilate_radius"):
+        cfg.dilate_radius = args.dilate_radius
     # -------------------------------------------
 
     if args.dry_run:

--- a/v3_tune_params.py
+++ b/v3_tune_params.py
@@ -46,7 +46,7 @@ if __name__ == "__main__":
     ap.add_argument("--mask-suffix", default="_mask", help="suffix added to image stem to get GT mask name")
     ap.add_argument("--sample", type=int, default=200, help="number of images to sample for quick tuning")
     ap.add_argument("--trials", type=int, default=60, help="random trials (>=30 추천)")
-    ap.add_argument("--gate", choices=["fixed","shemo"], default="shemo")
+    ap.add_argument("--gate", choices=["fixed","shemo"], default="fixed")
     args = ap.parse_args()
 
     image_root = Path(args.images); masks_root = Path(args.masks)
@@ -76,7 +76,7 @@ if __name__ == "__main__":
                         gate=args.gate,
                         lower_half_threshold=lth if lth is not None else 0.5,
                         gate_offset_frac=off if off is not None else 0.08,
-                        gate_lr_margin_frac=lr if lr is not None else 1/6)
+                        gate_lr_margin_frac=lr if lr is not None else 0.0)
 
         ious = []
         for ip in tqdm(imgs, desc=f"trial {t+1}/{args.trials}", leave=False):


### PR DESCRIPTION
## Summary
- Remove left/right margin by default in `RoiConfig` and add optional dilation and ROI padding controls
- Make CLI default to a fixed gate while exposing padding and dilation arguments
- Update tuning script to respect zero margin and fixed gate defaults

## Testing
- `python -m py_compile v3_roi_pipeline.py v3_main.py v3_tune_params.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd0bd16a3c832b84bab6fffd9b731c