### PR TITLE
feat: add two-stage ROI segmentation pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,40 @@
 # urp3_meshi
 
-Utilities for training and evaluating a U-Net model on CP-AnemiC ROI images.
+Two-stage conjunctival ROI segmentation utilities.
 
-## Prediction outputs
+## Files
+- `main.py`: CLI entry point for training and inference.
+- `train.py`: training loops for Stage-1 (full eye) and Stage-2 (ROI fine-tuning).
+- `datasets.py`: generic dataset loader supporting mask suffix and augmentation.
+- `unet.py`: lightweight U-Net model.
+- `roi_utils.py`: optional Haar cascade eye detector used during inference.
 
-During validation, `save_preds` stores three image types:
+## Usage
+### Stage-1 (full eye -> ROI)
+```
+python main.py train-stage1 \
+    --img-root ConjunctivalImages \
+    --mask-root ConjunctivalImages/palpebral \
+    --mask-suffix _palpebral \
+    --out stage1.pt
+```
 
-- `*_pred.png`: binary mask of the predicted region.
-- `*_roi.png`: original image masked by the prediction. Use this file for Hb prediction.
-- `*_overlay.png`: overlay of the mask for visualization only.
+### Stage-2 fine-tuning (cropped ROI images)
+```
+python main.py finetune-stage2 \
+    --img-root CP_AnemiC \
+    --mask-root CP_AnemiC \
+    --mask-suffix _mask \
+    --ckpt stage1.pt \
+    --out stage2.pt
+```
 
+### Inference on new full-eye images
+```
+python main.py infer \
+    --img-root new_images \
+    --ckpt stage2.pt \
+    --use-eye-detector
+```
+
+Prediction files saved in `--out-dir` include the binary mask (`*_mask.png`) and the color ROI (`*_roi.png`) preserving original colours.

--- a/datasets.py
+++ b/datasets.py
@@ -1,0 +1,49 @@
+import cv2
+import numpy as np
+from pathlib import Path
+from torch.utils.data import Dataset
+import albumentations as A
+
+
+class BaseConjDataset(Dataset):
+    """Load image/mask pairs, supporting optional mask suffix and augmentation."""
+
+    def __init__(self, img_root, mask_root=None, mask_suffix="", img_size=256,
+                 augment=False, exts=(".jpg", ".jpeg", ".png", ".tif", ".tiff")):
+        self.img_root = Path(img_root)
+        self.mask_root = Path(mask_root) if mask_root else self.img_root
+        self.mask_suffix = mask_suffix
+        self.exts = {e.lower() for e in exts}
+
+        self.pairs = []
+        for img_path in self.img_root.iterdir():
+            if img_path.suffix.lower() in self.exts:
+                stem = img_path.stem
+                mask_path = self.mask_root / f"{stem}{mask_suffix}.png"
+                if mask_path.exists():
+                    self.pairs.append((str(img_path), str(mask_path)))
+
+        self.transform = (
+            A.Compose([
+                A.Resize(img_size, img_size),
+                A.HorizontalFlip(p=0.5),
+                A.RandomRotate90(p=0.5),
+                A.ShiftScaleRotate(shift_limit=0.05, scale_limit=0.1,
+                                   rotate_limit=15, border_mode=cv2.BORDER_REFLECT_101, p=0.5),
+                A.HueSaturationValue(p=0.15),
+                A.RandomBrightnessContrast(p=0.15),
+            ]) if augment else A.Compose([A.Resize(img_size, img_size)])
+        )
+
+    def __len__(self):
+        return len(self.pairs)
+
+    def __getitem__(self, idx):
+        img_fp, mask_fp = self.pairs[idx]
+        img = cv2.imread(img_fp)
+        mask = cv2.imread(mask_fp, cv2.IMREAD_GRAYSCALE)
+        aug = self.transform(image=img, mask=mask)
+        img, mask = aug["image"], aug["mask"]
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB).transpose(2, 0, 1) / 255.0
+        mask = (mask > 127).astype(np.float32)[None, ...]
+        return img, mask

--- a/main.py
+++ b/main.py
@@ -1,0 +1,53 @@
+import argparse
+from train import train_stage1, finetune_stage2, run_inference
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Conjunctiva ROI Pipeline")
+    sub = parser.add_subparsers(dest="cmd")
+
+    s1 = sub.add_parser("train-stage1")
+    s1.add_argument("--img-root", required=True)
+    s1.add_argument("--mask-root", required=True)
+    s1.add_argument("--mask-suffix", default="", help="mask file suffix, e.g. _palpebral")
+    s1.add_argument("--img-size", type=int, default=256)
+    s1.add_argument("--epochs", type=int, default=40)
+    s1.add_argument("--batch", type=int, default=8)
+    s1.add_argument("--lr", type=float, default=1e-3)
+    s1.add_argument("--out", default="stage1.pt")
+
+    s2 = sub.add_parser("finetune-stage2")
+    s2.add_argument("--img-root", required=True)
+    s2.add_argument("--mask-root", required=True)
+    s2.add_argument("--mask-suffix", default="_mask")
+    s2.add_argument("--img-size", type=int, default=256)
+    s2.add_argument("--epochs", type=int, default=20)
+    s2.add_argument("--batch", type=int, default=8)
+    s2.add_argument("--lr", type=float, default=1e-4)
+    s2.add_argument("--ckpt", required=True, help="Stage-1 checkpoint path")
+    s2.add_argument("--out", default="stage2.pt")
+
+    inf = sub.add_parser("infer")
+    inf.add_argument("--img-root", required=True)
+    inf.add_argument("--ckpt", required=True)
+    inf.add_argument("--img-size", type=int, default=256)
+    inf.add_argument("--out-dir", default="preds")
+    inf.add_argument("--use-eye-detector", action="store_true")
+
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    if args.cmd == "train-stage1":
+        train_stage1(args)
+    elif args.cmd == "finetune-stage2":
+        finetune_stage2(args)
+    elif args.cmd == "infer":
+        run_inference(args)
+    else:
+        print("사용법: train-stage1 | finetune-stage2 | infer")
+
+
+if __name__ == "__main__":
+    main()

--- a/roi_utils.py
+++ b/roi_utils.py
@@ -1,0 +1,18 @@
+import cv2
+
+
+def detect_eye_region(img):
+    """Haar cascade 기반의 간단한 눈 영역 검출. 실패 시 전체 이미지 반환."""
+    gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+    cascade = cv2.CascadeClassifier(cv2.data.haarcascades +
+                                    "haarcascade_eye_tree_eyeglasses.xml")
+    eyes = cascade.detectMultiScale(gray, 1.1, 3)
+    if len(eyes) == 0:
+        h, w = img.shape[:2]
+        return 0, 0, w, h
+    x, y, w, h = max(eyes, key=lambda e: e[2] * e[3])
+    pad = int(0.1 * w)
+    x1, y1 = max(0, x - pad), max(0, y - pad)
+    x2 = min(img.shape[1], x + w + pad)
+    y2 = min(img.shape[0], y + h + pad)
+    return x1, y1, x2, y2

--- a/train.py
+++ b/train.py
@@ -1,0 +1,119 @@
+import os
+from glob import glob
+import torch
+from torch.utils.data import DataLoader, random_split
+import torch.optim as optim
+import torch.nn.functional as F
+import numpy as np
+from tqdm import tqdm
+import cv2
+
+from datasets import BaseConjDataset
+from unet import UNet
+from roi_utils import detect_eye_region
+
+
+def _make_loaders(img_root, mask_root, mask_suffix, img_size, batch, augment):
+    ds = BaseConjDataset(img_root, mask_root, mask_suffix,
+                         img_size=img_size, augment=augment)
+    val_len = max(1, int(len(ds) * 0.1))
+    train_ds, val_ds = random_split(
+        ds, [len(ds) - val_len, val_len],
+        generator=torch.Generator().manual_seed(0)
+    )
+    train_loader = DataLoader(train_ds, batch_size=batch, shuffle=True)
+    val_loader = DataLoader(val_ds, batch_size=batch)
+    return train_loader, val_loader
+
+
+def _epoch(model, loader, opt=None, device="cuda"):
+    if opt:
+        model.train()
+    else:
+        model.eval()
+    tot_loss, tot_iou, count = 0, 0, 0
+    for img, mask in loader:
+        img, mask = img.to(device), mask.to(device)
+        pred = model(img)
+        loss = F.binary_cross_entropy(pred, mask)
+        if opt:
+            opt.zero_grad()
+            loss.backward()
+            opt.step()
+        iou = ((pred > 0.5) & (mask > 0.5)).float().sum() / \
+              ((pred > 0.5) | (mask > 0.5)).float().sum().clamp_min(1.0)
+        tot_loss += loss.item() * len(img)
+        tot_iou += iou.item() * len(img)
+        count += len(img)
+    return tot_loss / count, tot_iou / count
+
+
+def train_stage1(args):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = UNet().to(device)
+    train_loader, val_loader = _make_loaders(args.img_root, args.mask_root,
+                                             args.mask_suffix, args.img_size,
+                                             args.batch, augment=True)
+    opt = optim.Adam(model.parameters(), lr=args.lr)
+    best_iou, best_w = 0.0, args.out
+    for ep in range(1, args.epochs + 1):
+        tl, tiou = _epoch(model, train_loader, opt, device)
+        vl, viou = _epoch(model, val_loader, None, device)
+        print(f"[Stage1][Ep {ep:03d}] Train {tl:.3f}/{tiou:.3f}  Val {vl:.3f}/{viou:.3f}")
+        if viou > best_iou:
+            best_iou = viou
+            torch.save(model.state_dict(), best_w)
+    print("Stage-1 best model saved:", best_w)
+
+
+def finetune_stage2(args):
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = UNet().to(device)
+    model.load_state_dict(torch.load(args.ckpt, map_location=device))
+    train_loader, val_loader = _make_loaders(args.img_root, args.mask_root,
+                                             args.mask_suffix, args.img_size,
+                                             args.batch, augment=True)
+    opt = optim.Adam(model.parameters(), lr=args.lr)
+    best_iou, best_w = 0.0, args.out
+    for ep in range(1, args.epochs + 1):
+        tl, tiou = _epoch(model, train_loader, opt, device)
+        vl, viou = _epoch(model, val_loader, None, device)
+        print(f"[Stage2][Ep {ep:03d}] Train {tl:.3f}/{tiou:.3f}  Val {vl:.3f}/{viou:.3f}")
+        if viou > best_iou:
+            best_iou = viou
+            torch.save(model.state_dict(), best_w)
+    print("Stage-2 best model saved:", best_w)
+
+
+def run_inference(args):
+    os.makedirs(args.out_dir, exist_ok=True)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    model = UNet().to(device)
+    model.load_state_dict(torch.load(args.ckpt, map_location=device))
+    model.eval()
+
+    exts = {".jpg", ".jpeg", ".png", ".tif", ".tiff"}
+    img_files = [p for p in glob(os.path.join(args.img_root, "*"))
+                 if os.path.splitext(p)[1].lower() in exts]
+
+    for fp in tqdm(img_files, desc="infer"):
+        img = cv2.imread(fp)
+        if args.use_eye_detector:
+            x1, y1, x2, y2 = detect_eye_region(img)
+            img_crop = img[y1:y2, x1:x2].copy()
+        else:
+            img_crop = img.copy()
+
+        orig = img_crop.copy()
+        im_res = cv2.resize(img_crop, (args.img_size, args.img_size))
+        tensor = cv2.cvtColor(im_res, cv2.COLOR_BGR2RGB).transpose(2, 0, 1)
+        tensor = torch.tensor(tensor / 255.0, dtype=torch.float32).unsqueeze(0).to(device)
+
+        with torch.no_grad():
+            pred = model(tensor)[0, 0].cpu().numpy()
+
+        mask = (pred > 0.5).astype(np.uint8) * 255
+        roi_color = cv2.bitwise_and(orig, orig, mask=mask)
+        stem = os.path.splitext(os.path.basename(fp))[0]
+        cv2.imwrite(os.path.join(args.out_dir, f"{stem}_mask.png"), mask)
+        cv2.imwrite(os.path.join(args.out_dir, f"{stem}_roi.png"), roi_color)

--- a/unet.py
+++ b/unet.py
@@ -1,0 +1,41 @@
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class DoubleConv(nn.Module):
+    def __init__(self, in_c, out_c):
+        super().__init__()
+        self.block = nn.Sequential(
+            nn.Conv2d(in_c, out_c, 3, padding=1),
+            nn.BatchNorm2d(out_c),
+            nn.ReLU(inplace=True),
+            nn.Conv2d(out_c, out_c, 3, padding=1),
+            nn.BatchNorm2d(out_c),
+            nn.ReLU(inplace=True),
+        )
+
+    def forward(self, x):
+        return self.block(x)
+
+
+class UNet(nn.Module):
+    def __init__(self, in_c=3, out_c=1, base=64):
+        super().__init__()
+        self.d1 = DoubleConv(in_c, base)
+        self.d2 = DoubleConv(base, base * 2)
+        self.d3 = DoubleConv(base * 2, base * 4)
+        self.u1 = DoubleConv(base * 4 + base * 2, base * 2)
+        self.u2 = DoubleConv(base * 2 + base, base)
+        self.out = nn.Conv2d(base, out_c, 1)
+        self.pool = nn.MaxPool2d(2)
+
+    def forward(self, x):
+        c1 = self.d1(x)
+        c2 = self.d2(self.pool(c1))
+        c3 = self.d3(self.pool(c2))
+        u1 = F.interpolate(c3, scale_factor=2, mode="bilinear", align_corners=False)
+        u1 = self.u1(torch.cat([u1, c2], dim=1))
+        u2 = F.interpolate(u1, scale_factor=2, mode="bilinear", align_corners=False)
+        u2 = self.u2(torch.cat([u2, c1], dim=1))
+        return torch.sigmoid(self.out(u2))


### PR DESCRIPTION
## Summary
- add standalone CLI with stage1/stage2/infer commands
- implement generic dataset loader supporting mask suffix
- provide training, UNet model, and optional eye detector utilities

## Testing
- `python -m py_compile main.py datasets.py unet.py train.py roi_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68bbeb49bb94832bba0724846e242f0d