### PR TITLE
Use recursive dataset with configurable options

### DIFF
--- a/datasets.py
+++ b/datasets.py
@@ -47,3 +47,54 @@ class BaseConjDataset(Dataset):
         img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB).transpose(2, 0, 1) / 255.0
         mask = (mask > 127).astype(np.float32)[None, ...]
         return img, mask
+
+
+class ConjAnemiaDataset(Dataset):
+    """Dataset that recursively scans folders for image/mask pairs.
+
+    This version searches all sub-directories under ``img_root`` using
+    ``Path.rglob("*.jpg")`` (and other extensions) so that images can be
+    organised in arbitrary nested structures.  Masks are expected to have the
+    same relative path under ``mask_root`` and use ``mask_suffix`` before the
+    ``.png`` extension.
+    """
+
+    def __init__(self, img_root, mask_root=None, mask_suffix="", img_size=256,
+                 augment=False, exts=(".jpg", ".jpeg", ".png", ".tif", ".tiff")):
+        self.img_root = Path(img_root)
+        self.mask_root = Path(mask_root) if mask_root else self.img_root
+        self.mask_suffix = mask_suffix
+        self.exts = {e.lower() for e in exts}
+
+        self.pairs = []
+        for ext in self.exts:
+            for img_path in self.img_root.rglob(f"*{ext}"):
+                rel = img_path.relative_to(self.img_root)
+                mask_path = self.mask_root / rel.parent / f"{img_path.stem}{mask_suffix}.png"
+                if mask_path.exists():
+                    self.pairs.append((str(img_path), str(mask_path)))
+
+        self.transform = (
+            A.Compose([
+                A.Resize(img_size, img_size),
+                A.HorizontalFlip(p=0.5),
+                A.RandomRotate90(p=0.5),
+                A.ShiftScaleRotate(shift_limit=0.05, scale_limit=0.1,
+                                   rotate_limit=15, border_mode=cv2.BORDER_REFLECT_101, p=0.5),
+                A.HueSaturationValue(p=0.15),
+                A.RandomBrightnessContrast(p=0.15),
+            ]) if augment else A.Compose([A.Resize(img_size, img_size)])
+        )
+
+    def __len__(self):
+        return len(self.pairs)
+
+    def __getitem__(self, idx):
+        img_fp, mask_fp = self.pairs[idx]
+        img = cv2.imread(img_fp)
+        mask = cv2.imread(mask_fp, cv2.IMREAD_GRAYSCALE)
+        aug = self.transform(image=img, mask=mask)
+        img, mask = aug["image"], aug["mask"]
+        img = cv2.cvtColor(img, cv2.COLOR_BGR2RGB).transpose(2, 0, 1) / 255.0
+        mask = (mask > 127).astype(np.float32)[None, ...]
+        return img, mask

--- a/main.py
+++ b/main.py
@@ -1,9 +1,11 @@
 import argparse
+import json
 from train import train_stage1, finetune_stage2, run_inference
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Conjunctiva ROI Pipeline")
+    parser.add_argument("--config", help="Path to JSON config file", default=None)
     sub = parser.add_subparsers(dest="cmd")
 
     s1 = sub.add_parser("train-stage1")
@@ -34,7 +36,13 @@ def parse_args():
     inf.add_argument("--out-dir", default="preds")
     inf.add_argument("--use-eye-detector", action="store_true")
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.config:
+        with open(args.config, "r") as f:
+            cfg = json.load(f)
+        for k, v in cfg.items():
+            setattr(args, k.replace('-', '_'), v)
+    return args
 
 
 def main():

--- a/train.py
+++ b/train.py
@@ -8,14 +8,14 @@ import numpy as np
 from tqdm import tqdm
 import cv2
 
-from datasets import BaseConjDataset
+from datasets import ConjAnemiaDataset
 from unet import UNet
 from roi_utils import detect_eye_region
 
 
 def _make_loaders(img_root, mask_root, mask_suffix, img_size, batch, augment):
-    ds = BaseConjDataset(img_root, mask_root, mask_suffix,
-                         img_size=img_size, augment=augment)
+    ds = ConjAnemiaDataset(img_root, mask_root, mask_suffix,
+                           img_size=img_size, augment=augment)
     val_len = max(1, int(len(ds) * 0.1))
     train_ds, val_ds = random_split(
         ds, [len(ds) - val_len, val_len],


### PR DESCRIPTION
## Summary
- add `ConjAnemiaDataset` that scans subfolders using `Path.rglob` to build image/mask pairs
- switch training pipeline to use the new dataset
- allow passing common options (e.g., `mask_suffix`) through CLI or JSON config

## Testing
- `python -m py_compile datasets.py train.py main.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd87e0838c832b83c7282ff087a46f